### PR TITLE
Add .sublime-syntax file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.svn
+.sass-cache
+node_modules
+js/components
+_vendor
+site/online/**/*
+!site/online/.htaccess
+.DS_Store
+Thumbs.db
+npm-debug.log
+*.sublime-*
+*.zip
+*.gzip
+*.gz
+*.tar

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ site/online/**/*
 .DS_Store
 Thumbs.db
 npm-debug.log
-*.sublime-*
+*.sublime-project
+*.sublime-workspace
 *.zip
 *.gzip
 *.gz

--- a/Nunjucks.sublime-syntax
+++ b/Nunjucks.sublime-syntax
@@ -1,0 +1,435 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: HTML (Nunjucks)
+file_extensions:
+  - nunjucks
+  - nunjs
+  - njk
+  - html
+scope: text.html.nunjucks
+contexts:
+  main:
+    - match: "{% comment %}"
+      push:
+        - meta_scope: comment.block.nunjucks
+        - match: "{% endcomment %}"
+          pop: true
+    - match: "{#"
+      push:
+        - meta_scope: comment.line.number-sign.nunjucks
+        - match: "#}"
+          pop: true
+    - match: "{{"
+      captures:
+        0: entity.tag.tagbraces.nunjucks
+      push:
+        - meta_scope: storage.type.variable.nunjucks
+        - match: "}}"
+          captures:
+            0: entity.tag.tagbraces.nunjucks
+          pop: true
+        - include: template_filter
+    - match: "{%-|{%"
+      captures:
+        0: entity.tag.tagbraces.nunjucks
+      push:
+        - meta_scope: storage.type.templatetag.nunjucks
+        - match: "-%}|%}"
+          captures:
+            0: entity.tag.tagbraces.nunjucks
+          pop: true
+        - include: template_tag
+        - include: template_filter
+    - match: '(<)([a-zA-Z0-9:]++)(?=[^>]*></\2>)'
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.html
+      push:
+        - meta_scope: meta.tag.any.html
+        - match: (>)(<)(/)(\2)(>)
+          captures:
+            1: punctuation.definition.tag.end.html
+            2: punctuation.definition.tag.begin.html meta.scope.between-tag-pair.html
+            3: punctuation.definition.tag.begin.html
+            4: entity.name.tag.html
+            5: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
+    - match: (<\?)(xml)
+      captures:
+        1: punctuation.definition.tag.html
+        2: entity.name.tag.xml.html
+      push:
+        - meta_scope: meta.tag.preprocessor.xml.html
+        - match: (\?>)
+          captures:
+            1: punctuation.definition.tag.html
+            2: entity.name.tag.xml.html
+          pop: true
+        - include: tag-generic-attribute
+        - include: string-double-quoted
+        - include: string-single-quoted
+    - match: <!--
+      captures:
+        0: punctuation.definition.comment.html
+      push:
+        - meta_scope: comment.block.html
+        - match: '--\s*>'
+          captures:
+            0: punctuation.definition.comment.html
+          pop: true
+        - match: "--"
+          scope: invalid.illegal.bad-comments-or-CDATA.html
+        - include: embedded-code
+    - match: <!
+      captures:
+        0: punctuation.definition.tag.html
+      push:
+        - meta_scope: meta.tag.sgml.html
+        - match: ">"
+          captures:
+            0: punctuation.definition.tag.html
+          pop: true
+        - match: (?i:DOCTYPE)
+          captures:
+            1: entity.name.tag.doctype.html
+          push:
+            - meta_scope: meta.tag.sgml.doctype.html
+            - match: (?=>)
+              captures:
+                1: entity.name.tag.doctype.html
+              pop: true
+            - match: '"[^">]*"'
+              scope: string.quoted.double.doctype.identifiers-and-DTDs.html
+        - match: '\[CDATA\['
+          push:
+            - meta_scope: constant.other.inline-data.html
+            - match: "]](?=>)"
+              pop: true
+        - match: (\s*)(?!--|>)\S(\s*)
+          scope: invalid.illegal.bad-comments-or-CDATA.html
+    - include: embedded-code
+    - match: '(?:^\s+)?(<)((?i:style))\b(?![^>]*/>)'
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.style.html
+        3: punctuation.definition.tag.html
+      push:
+        - meta_scope: source.css.embedded.html
+        - match: (</)((?i:style))(>)(?:\s*\n)?
+          captures:
+            1: punctuation.definition.tag.begin.html
+            2: entity.name.tag.style.html
+            3: punctuation.definition.tag.html
+          pop: true
+        - include: tag-stuff
+        - match: (>)
+          captures:
+            1: punctuation.definition.tag.end.html
+          push:
+            - match: (?=</(?i:style))
+              pop: true
+            - match: "{% comment %}"
+              push:
+                - meta_scope: comment.block.nunjucks
+                - match: "{% endcomment %}"
+                  pop: true
+            - match: "{#"
+              push:
+                - meta_scope: comment.line.number-sign.nunjucks
+                - match: "#}"
+                  pop: true
+            - match: "{{"
+              captures:
+                0: entity.tag.tagbraces.nunjucks
+              push:
+                - meta_scope: storage.type.variable.nunjucks
+                - match: "}}"
+                  captures:
+                    0: entity.tag.tagbraces.nunjucks
+                  pop: true
+                - include: template_filter
+            - match: "{%"
+              captures:
+                0: entity.tag.tagbraces.nunjucks
+              push:
+                - meta_scope: storage.type.templatetag.nunjucks
+                - match: "%}"
+                  captures:
+                    0: entity.tag.tagbraces.nunjucks
+                  pop: true
+                - include: template_tag
+                - include: template_filter
+            - include: embedded-code
+            - include: scope:source.css.nunjucks
+    - match: '(?:^\s+)?(<)((?i:script))\b(?![^>]*/>)'
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.script.html
+      push:
+        - meta_scope: source.js.embedded.html
+        - match: (?<=</(script|SCRIPT))(>)(?:\s*\n)?
+          captures:
+            2: punctuation.definition.tag.html
+          pop: true
+        - include: tag-stuff
+        - match: (?<!</(?:script|SCRIPT))(>)
+          captures:
+            1: punctuation.definition.tag.end.html
+            2: entity.name.tag.script.html
+          push:
+            - match: (</)((?i:script))
+              captures:
+                1: punctuation.definition.tag.end.html
+                2: entity.name.tag.script.html
+              pop: true
+            - match: "{% comment %}"
+              push:
+                - meta_scope: comment.block.nunjucks
+                - match: "{% endcomment %}"
+                  pop: true
+            - match: "{#"
+              push:
+                - meta_scope: comment.line.number-sign.nunjucks
+                - match: "#}"
+                  pop: true
+            - match: "{{"
+              captures:
+                0: entity.tag.tagbraces.nunjucks
+              push:
+                - meta_scope: storage.type.variable.nunjucks
+                - match: "}}"
+                  captures:
+                    0: entity.tag.tagbraces.nunjucks
+                  pop: true
+                - include: template_filter
+            - match: "{%"
+              captures:
+                0: entity.tag.tagbraces.nunjucks
+              push:
+                - meta_scope: storage.type.templatetag.nunjucks
+                - match: "%}"
+                  captures:
+                    0: entity.tag.tagbraces.nunjucks
+                  pop: true
+                - include: template_tag
+                - include: template_filter
+            - match: (//).*?((?=</script)|$\n?)
+              scope: comment.line.double-slash.js
+              captures:
+                1: punctuation.definition.comment.js
+            - match: /\*
+              captures:
+                0: punctuation.definition.comment.js
+              push:
+                - meta_scope: comment.block.js
+                - match: \*/|(?=</script)
+                  captures:
+                    0: punctuation.definition.comment.js
+                  pop: true
+            - include: php
+            - include: scope:source.js
+    - match: (</?)((?i:body|head|html)\b)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.structure.any.html
+      push:
+        - meta_scope: meta.tag.structure.any.html
+        - match: (>)
+          captures:
+            1: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
+    - match: (</?)((?i:address|blockquote|dd|div|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|menu|pre)\b)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.block.any.html
+      push:
+        - meta_scope: meta.tag.block.any.html
+        - match: (>)
+          captures:
+            1: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
+    - match: (</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\b)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.inline.any.html
+      push:
+        - meta_scope: meta.tag.inline.any.html
+        - match: "((?: ?/)?>)"
+          captures:
+            1: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
+    - match: "(</?)([a-zA-Z0-9:]+)"
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.other.html
+      push:
+        - meta_scope: meta.tag.other.html
+        - match: (>)
+          captures:
+            1: punctuation.definition.tag.end.html
+          pop: true
+        - include: tag-stuff
+    - include: entities
+    - match: <>
+      scope: invalid.illegal.incomplete.html
+    - match: <
+      scope: invalid.illegal.bad-angle-bracket.html
+  embedded-code:
+    - include: ruby
+    - include: php
+    - include: python
+  entities:
+    - match: "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)"
+      scope: constant.character.entity.html
+      captures:
+        1: punctuation.definition.entity.html
+        3: punctuation.definition.entity.html
+    - match: "&"
+      scope: invalid.illegal.bad-ampersand.html
+  php:
+    - match: (?=(^\s*)?<\?)
+      push:
+        - match: (?!(^\s*)?<\?)
+          pop: true
+        - include: scope:source.php
+  python:
+    - match: (?:^\s*)<\?python(?!.*\?>)
+      push:
+        - meta_scope: source.python.embedded.html
+        - match: \?>(?:\s*$\n)?
+          pop: true
+        - include: scope:source.python
+  ruby:
+    - match: "<%+#"
+      captures:
+        0: punctuation.definition.comment.erb
+      push:
+        - meta_scope: comment.block.erb
+        - match: "%>"
+          captures:
+            0: punctuation.definition.comment.erb
+          pop: true
+    - match: <%+(?!>)=?
+      captures:
+        0: punctuation.section.embedded.ruby
+      push:
+        - meta_scope: source.ruby.embedded.html
+        - match: "-?%>"
+          captures:
+            0: punctuation.section.embedded.ruby
+          pop: true
+        - match: (#).*?(?=-?%>)
+          scope: comment.line.number-sign.ruby
+          captures:
+            1: punctuation.definition.comment.ruby
+        - include: scope:source.ruby
+    - match: <\?r(?!>)=?
+      captures:
+        0: punctuation.section.embedded.ruby.nitro
+      push:
+        - meta_scope: source.ruby.nitro.embedded.html
+        - match: '-?\?>'
+          captures:
+            0: punctuation.section.embedded.ruby.nitro
+          pop: true
+        - match: (#).*?(?=-?\?>)
+          scope: comment.line.number-sign.ruby.nitro
+          captures:
+            1: punctuation.definition.comment.ruby.nitro
+        - include: scope:source.ruby
+  string-double-quoted:
+    - match: '"'
+      captures:
+        0: punctuation.definition.string.begin.html
+      push:
+        - meta_scope: string.quoted.double.html
+        - match: '"'
+          captures:
+            0: punctuation.definition.string.end.html
+          pop: true
+        - include: embedded-code
+        - include: entities
+  string-single-quoted:
+    - match: "'"
+      captures:
+        0: punctuation.definition.string.begin.html
+      push:
+        - meta_scope: string.quoted.single.html
+        - match: "'"
+          captures:
+            0: punctuation.definition.string.end.html
+          pop: true
+        - include: embedded-code
+        - include: entities
+  tag-generic-attribute:
+    - match: '\b([a-zA-Z\-:]+)'
+      scope: entity.other.attribute-name.html
+  tag-id-attribute:
+    - match: \b(id)\b\s*(=)
+      captures:
+        1: entity.other.attribute-name.id.html
+        2: punctuation.separator.key-value.html
+      push:
+        - meta_scope: meta.attribute-with-value.id.html
+        - match: (?<='|")
+          captures:
+            1: entity.other.attribute-name.id.html
+            2: punctuation.separator.key-value.html
+          pop: true
+        - match: '"'
+          captures:
+            0: punctuation.definition.string.begin.html
+          push:
+            - meta_scope: string.quoted.double.html
+            - meta_content_scope: meta.toc-list.id.html
+            - match: '"'
+              captures:
+                0: punctuation.definition.string.end.html
+              pop: true
+            - include: embedded-code
+            - include: entities
+        - match: "'"
+          captures:
+            0: punctuation.definition.string.begin.html
+          push:
+            - meta_scope: string.quoted.single.html
+            - meta_content_scope: meta.toc-list.id.html
+            - match: "'"
+              captures:
+                0: punctuation.definition.string.end.html
+              pop: true
+            - include: embedded-code
+            - include: entities
+  tag-stuff:
+    - include: tag-id-attribute
+    - include: tag-generic-attribute
+    - include: string-double-quoted
+    - include: string-single-quoted
+    - include: embedded-code
+  template_filter:
+    - match: (add|addslashes|capfirst|center|cut|date|default|default_if_none|dictsort|dictsortreversed|divisibleby|escape|escapejs|filesizeformat|first|fix_ampersands|floatformat|force_escape|get_digit|iriencode|join|last|length|length_is|linebreaks|linebreaksbr|linenumbers|ljust|lower|make_list|phone2numeric|pluralize|pprint|random|removetags|rjust|safe|safeseq|slice|slugify|stringformat|striptags|time|timesince|timeutil|title|truncatewords|truncatewords_html|unordered_list|upper|urlencode|urlize|urlizetrunc|wordcount|wordwrap|yesno|apnumber|intcomma|intword|naturalday|ordinal|STATIC_PREFIX)\b
+      scope: keyword.control.filter.nunjucks
+    - match: ':"|"'
+      push:
+        - meta_scope: storage.type.attr.nunjucks
+        - match: '"'
+          pop: true
+    - match: ':\''|\'''
+      push:
+        - meta_scope: storage.type.attr.nunjucks
+        - match: \'
+          pop: true
+    - match: \|
+      scope: string.unquoted.filter-pipe.nunjucks
+    - match: "[a-zA-Z0-9_.]+"
+      scope: string.unquoted.tag-string.nunjucks
+  template_tag:
+    - match: \b(autoescape|endautoescape|block|endblock|blocktrans|endblocktrans|trans|plural|debug|extends|filter|firstof|for|empty|endfor|if|elif|else|endif|include|ifchanged|endifchanged|ifequal|endifequal|ifnotequal|endifnotequal|load|from|low|regroup|ssi|spaceless|endspaceless|templatetag|widthratio|with|endwith|csrf_token|cycle|url|lorem|thumbnail|endthumbnail|get_static_prefix)\b
+      scope: keyword.control.tag-name.nunjucks
+    - match: \b(and|or|not|in|by|as)\b
+      scope: keyword.operator.nunjucks

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# sublime-nunjucks
+# Sublime-nunjucks
 
-A Nunjucks syntax definition specifically for Sublime Text.
-
+A [Nunjucks](https://mozilla.github.io/nunjucks/) syntax definition specifically for Sublime Text 2 and 3.


### PR DESCRIPTION
Added auto-converted .sublime-syntax file, to provide support on Sublime Text Build 3084+ (see http://www.sublimetext.com/docs/3/syntax.html and http://docs.sublimetext.info/en/latest/extensibility/syntaxdefs.html)
