### PR TITLE
update filetype

### DIFF
--- a/Nunjucks.tmLanguage
+++ b/Nunjucks.tmLanguage
@@ -8,6 +8,7 @@
     <array>
       <string>nunjucks</string>
       <string>nunjs</string>
+      <string>njk</string>
       <string>html</string>
     </array>
 


### PR DESCRIPTION
https://mozilla.github.io/nunjucks/templating.html#file-extensions

> Although you are free to use any file extension you wish for your Nunjucks template files, the Nunjucks community has adopted `.njk`.
> If you are developing tools or editor syntax helpers for Nunjucks, please include recognition of the `.njk` extension.