### PR TITLE
Support .njk filename

### DIFF
--- a/Nunjucks.tmLanguage
+++ b/Nunjucks.tmLanguage
@@ -7,7 +7,8 @@
     <key>fileTypes</key>
     <array>
       <string>nunjucks</string>
-      <string>nunjs</string>
+      <string>nunjs</string
+      <string>njk</string>
       <string>html</string>
     </array>
 


### PR DESCRIPTION
A Nunjucks file name can now end with `.njk`, with this change those file will be supported by your package.